### PR TITLE
[Bugfix/mail scheduling issue] Fix the issue that Celery scheduler is not running on Heroku host

### DIFF
--- a/src/Procfile
+++ b/src/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn stocksubscription.wsgi
+web: honcho start -f ProcfileHoncho

--- a/src/ProcfileHoncho
+++ b/src/ProcfileHoncho
@@ -1,0 +1,3 @@
+web: gunicorn stocksubscription.wsgi
+worker: celery -A stocksubscription worker -l info
+beat: celery -A stocksubscription beat -l INFO --scheduler django_celery_beat.schedulers:DatabaseScheduler

--- a/src/mail/tasks.py
+++ b/src/mail/tasks.py
@@ -35,7 +35,7 @@ def send_email_task(mailto, tickers):
     return None
 
 
-@shared_task()
+@shared_task
 def send_digest():
     all_sub = Subscription.objects.all()
     ticker_string = ""

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -20,6 +20,7 @@ django-timezone-field==4.2.1
 future==0.18.2
 gunicorn==20.1.0
 homebrew==0.2.4
+honcho==1.0.1
 idna==3.2
 jmespath==0.10.0
 kombu==5.1.0


### PR DESCRIPTION
Configure Procfile using Honcho to run Celery in Heroku, bringing back scheduled mail service on the web app